### PR TITLE
Remove the Now Playing menu item from the Joggler skin home menu

### DIFF
--- a/share/jive/applets/JogglerSkin/JogglerSkinApplet.lua
+++ b/share/jive/applets/JogglerSkin/JogglerSkinApplet.lua
@@ -95,7 +95,7 @@ function param(self)
         return {
 		THUMB_SIZE = 40,
 		THUMB_SIZE_MENU = 40,
-		NOWPLAYING_MENU = true,
+		NOWPLAYING_MENU = false,
 		-- NOWPLAYING_TRACKINFO_LINES used in assisting scroll behavior animation on NP
 		-- 3 is for a three line track, artist, and album (e.g., SBtouch)
 		-- 2 is for a two line track, artist+album (e.g., SBradio, SBcontroller)


### PR DESCRIPTION
It’s redundant, as we have a button to jump to the Now Playing screen on every other screen.