### PR TITLE
Force use of IPv4 UDP socket

### DIFF
--- a/share/jive/jive/net/SocketUdp.lua
+++ b/share/jive/jive/net/SocketUdp.lua
@@ -68,7 +68,14 @@ oo.class(_M, Socket)
 local _createUdpSocket = socket.protect(function(localport)
 	--log:debug("_createUdpSocket()")
 	
-	local sock = socket.try(socket.udp())
+	-- Make sure that we end up with an IPv4 UDP.
+	local sock
+	if socket.udp4~=nil then
+		sock = socket.try(socket.udp4())
+	else
+		sock = socket.try(socket.udp())
+	end
+
 	-- create a try function that closes 'c' on error
     local try = socket.newtry(function() sock:close() end)
     -- do everything reassured c will be closed


### PR DESCRIPTION
The commit to resolve:
  https://github.com/diegonehab/luasocket/issues/147
in lua-socket to support IPv6 has changed the behaviour of socket.udp()
so that the socket isn't created until the first packet is transmitted.
This is to allow the create family to be used. But this stops us from
being up to set the broadcast flag on the socket, so no socket exists.
The result in jivelite is that we fail to discover the SlimServer.

This commit looks for the existence of the udp4 function and calls that.
This allows us to support current lua-socket, and older deployments.

In an ideal world we'd support IPv6.